### PR TITLE
Printing arithmetic expressions as Scala notation strings

### DIFF
--- a/src/main/lift/arithmetic/Predicate.scala
+++ b/src/main/lift/arithmetic/Predicate.scala
@@ -34,4 +34,10 @@ object Predicate {
     val == = Value("==")
   }
 
+  /**
+    * Converts a Predicate to a Scala notation String which can be evaluated into a valid Predicate
+    */
+  def printToScalaString(p: Predicate): String =
+    s"Predicate(${ArithExpr.printToScalaString(p.lhs)}, ${ArithExpr.printToScalaString(p.rhs)}, ${p.op})"
+
 }

--- a/src/main/lift/arithmetic/Range.scala
+++ b/src/main/lift/arithmetic/Range.scala
@@ -32,6 +32,23 @@ object Range {
       case RangeUnknown => r
     }
   }
+
+  /**
+    * Converts a Range to a Scala notation String which can be evaluated into a valid Range
+    */
+  def printToScalaString(r: Range): String = r match {
+    case StartFromRange(start) =>             s"StartFromRange(${ArithExpr.printToScalaString(start)}"
+    case GoesToRange(end) =>                  s"GoesToRange(${ArithExpr.printToScalaString(end)}"
+    case RangeAdd(start, stop, step) =>       s"RangeAdd(${ArithExpr.printToScalaString(start)}, " +
+                                                       s"${ArithExpr.printToScalaString(stop)}, " +
+                                                       s"${ArithExpr.printToScalaString(step)})"
+    case RangeMul(start, stop, mul) =>        s"RangeMul(${ArithExpr.printToScalaString(start)}, " +
+                                                       s"${ArithExpr.printToScalaString(stop)}, " +
+                                                       s"${ArithExpr.printToScalaString(mul)})"
+    case RangeUnknown =>                      s"RangeUnknown"
+    case r =>
+      throw new NotImplementedError(s"Range $r is not supported in printing Range to Scala notation String")
+  }
 }
 
 class RangeUnknownException(msg: String) extends Exception(msg)


### PR DESCRIPTION
This functionality enables converting `ArithExpr` to strings that can later be evaluated into valid Scala `ArithExpr`. This replaces the old approach of calling `toString` of the `ArithExpr` subtypes which produce c-like strings and are supposed to be used for debugging only.

An example problem is printing `Pow(a, b)`: `toString` method produces `pow(a, b)`, while the new `printToScalaString` produces `Pow(a, b)`. 

An example user of this functionality is lift.rewriting.utils.ScalaPrinter.

